### PR TITLE
URL Cleanup

### DIFF
--- a/rebar.config.sample
+++ b/rebar.config.sample
@@ -129,7 +129,7 @@
 %% type, location and revision). Rebar currently support git, hg, bzr and svn.
 {deps, [application_name,
         {application_name, "1.0.*"},
-        {application_name, "1.0.*", {hg, "http://bitbucket.org/basho/rebar/", "f3626d5858a6"}}]}.
+        {application_name, "1.0.*", {hg, "https://bitbucket.org/basho/rebar/", "f3626d5858a6"}}]}.
 
 %% == Subdirectories ==
 


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://bitbucket.org/basho/rebar/ with 1 occurrences migrated to:  
  https://bitbucket.org/basho/rebar/ ([https](https://bitbucket.org/basho/rebar/) result 302).